### PR TITLE
De-couple zoom level from rendered image bounds

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,6 +191,7 @@ func main() {
 
 	go func() {
 		i := <-images
+		var fitZoom Zoom
 		for {
 			select {
 			case <-redraw:
@@ -204,7 +205,11 @@ func main() {
 				)
 				draw()
 			case <-zoomIn:
-				zoom += 10
+				if zoom < fitZoom && fitZoom < zoom+10 {
+					zoom = fitZoom
+				} else {
+					zoom += 10
+				}
 				resizedImage = zoom.TransImage(i)
 				draw()
 			case <-zoomOut:
@@ -229,6 +234,7 @@ func main() {
 				if zoom > 100 {
 					zoom = 100
 				}
+				fitZoom = zoom
 				resizedImage = zoom.TransImage(i)
 				draw()
 			case shift := <-shiftImg:
@@ -272,6 +278,7 @@ func main() {
 				if zoom > 100 {
 					zoom = 100
 				}
+				fitZoom = zoom
 				resizedImage = zoom.TransImage(i)
 				title = i.title
 				draw()


### PR DESCRIPTION
- Use separate channel for animation frames
- Use global zoom percentage

Uses a global zoom percentage that *is only reset when a new **image**, not a new **frame** is
loaded*, allowing zoom level to be kept when each frame is rendered.

Fixes #24
