### PR TITLE
Fix GIF frame from previous animation overwriting next static image

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -172,6 +172,7 @@ func Root(imageFiles []string, supported map[string]struct{}) {
 			select {
 			case currentImage = <-images:
 				stopAnimation <- struct{}{}
+				nextFrame = make(chan conversion.RGBRunes)
 				maxWidth, maxHeight := s.Size()
 				maxWidth = int(float32(maxWidth) / pixelHeight)
 				if maxWidth < maxHeight {
@@ -185,7 +186,6 @@ func Root(imageFiles []string, supported map[string]struct{}) {
 				fitZoom = currentZoom
 				if g, ok := currentImage.(*gif.Helper); ok {
 					stopAnimation = make(chan struct{})
-					nextFrame = make(chan conversion.RGBRunes)
 					zoomChan = make(chan Zoom)
 					go AnimateGif(g, nextFrame, stopAnimation, zoomChan)
 					zoomChan <- currentZoom

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -172,7 +172,6 @@ func Root(imageFiles []string, supported map[string]struct{}) {
 			select {
 			case currentImage = <-images:
 				stopAnimation <- struct{}{}
-				stopAnimation = make(chan struct{}, 1)
 				maxWidth, maxHeight := s.Size()
 				maxWidth = int(float32(maxWidth) / pixelHeight)
 				if maxWidth < maxHeight {
@@ -185,12 +184,14 @@ func Root(imageFiles []string, supported map[string]struct{}) {
 				}
 				fitZoom = currentZoom
 				if g, ok := currentImage.(*gif.Helper); ok {
+					stopAnimation = make(chan struct{})
 					nextFrame = make(chan conversion.RGBRunes)
 					zoomChan = make(chan Zoom)
 					go AnimateGif(g, nextFrame, stopAnimation, zoomChan)
 					zoomChan <- currentZoom
 					continue
 				}
+				stopAnimation = make(chan struct{}, 1)
 				resizedImage := currentZoom.TransImage(currentImage)
 				rgbRunes = conversion.RGBRunesFromImage(resizedImage)
 				currentWidth, currentHeight = rgbRunes.Width(), rgbRunes.Height()

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -172,6 +172,7 @@ func Root(imageFiles []string, supported map[string]struct{}) {
 			select {
 			case currentImage = <-images:
 				stopAnimation <- struct{}{}
+				stopAnimation = make(chan struct{}, 1)
 				nextFrame = make(chan conversion.RGBRunes)
 				maxWidth, maxHeight := s.Size()
 				maxWidth = int(float32(maxWidth) / pixelHeight)
@@ -185,13 +186,11 @@ func Root(imageFiles []string, supported map[string]struct{}) {
 				}
 				fitZoom = currentZoom
 				if g, ok := currentImage.(*gif.Helper); ok {
-					stopAnimation = make(chan struct{})
 					zoomChan = make(chan Zoom)
 					go AnimateGif(g, nextFrame, stopAnimation, zoomChan)
 					zoomChan <- currentZoom
 					continue
 				}
-				stopAnimation = make(chan struct{}, 1)
 				resizedImage := currentZoom.TransImage(currentImage)
 				rgbRunes = conversion.RGBRunesFromImage(resizedImage)
 				currentWidth, currentHeight = rgbRunes.Width(), rgbRunes.Height()


### PR DESCRIPTION
Sets the `nextFrame` channel to a new value *each time the image is updated*, which prevents reading any frames from the previous channel value that would likely be invalid for the current image.

Fixes #46 