### PR TITLE
Render errors non-fatally

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -84,31 +84,16 @@ func Root(imageFiles []string, supported map[string]struct{}) {
 		loadImage()
 		var (
 			fitZoom, currentZoom        Zoom
-			title                       string                   = <-titleChan
-			currentImage                image.Image              = <-images
+			title                       string
+			currentImage                image.Image
 			stopAnimation               chan struct{}            = make(chan struct{}, 1)
 			nextFrame                   chan conversion.RGBRunes = make(chan conversion.RGBRunes)
 			zoomChan                    chan Zoom                = make(chan Zoom)
 			rgbRunes                    conversion.RGBRunes
 			currentWidth, currentHeight int
-			maxWidth, maxHeight         int = Screen.Size()
 		)
 		zoomGif := func() {
 			zoomChan <- currentZoom
-		}
-		maxWidth = int(float32(maxWidth) / pixelHeight)
-		if maxWidth < maxHeight {
-			currentZoom = Zoom(uint(maxWidth) * 100 / uint(currentImage.Bounds().Max.X))
-		} else {
-			currentZoom = Zoom(uint(maxHeight) * 100 / uint(currentImage.Bounds().Max.Y))
-		}
-		if currentZoom > 100 {
-			currentZoom = 100
-		}
-		fitZoom = currentZoom
-		if g, ok := currentImage.(*gif.Helper); ok {
-			go AnimateGif(g, nextFrame, stopAnimation, zoomChan)
-			go zoomGif()
 		}
 		for {
 			select {
@@ -177,6 +162,9 @@ func Root(imageFiles []string, supported map[string]struct{}) {
 				yMod = 0
 				maxWidth, maxHeight := Screen.Size()
 				maxWidth = int(float32(maxWidth) / pixelHeight)
+				if currentImage == nil {
+					break
+				}
 				if maxWidth < maxHeight {
 					currentZoom = Zoom(maxWidth * 100 / currentImage.Bounds().Max.X)
 				} else {

--- a/internal/draw/draw.go
+++ b/internal/draw/draw.go
@@ -56,3 +56,26 @@ func Image(s tcell.Screen, rgbRunes conversion.RGBRunes, center image.Point) {
 		}
 	}
 }
+
+// Error draws an error to the screen.
+//
+// An error should be drawn if an image *cannot* be drawn. An error should not
+// be drawn *over* an image.
+func Error(s tcell.Screen, err error) {
+	status := "cannot draw:"
+	errStr := err.Error()
+	width, height := s.Size()
+
+	xOrigin := width / 2
+	yOrigin := (height - TitleBarPixels) / 2
+
+	statusStart := xOrigin - (len(status) / 2)
+	for i, r := range []rune(status) {
+		s.SetContent(statusStart+i, yOrigin+TitleBarPixels-1, r, nil, tcell.StyleDefault)
+	}
+
+	errStart := xOrigin - (len(errStr) / 2)
+	for i, r := range []rune(errStr) {
+		s.SetContent(errStart+i, yOrigin+TitleBarPixels, r, nil, tcell.StyleDefault)
+	}
+}

--- a/internal/draw/draw_test.go
+++ b/internal/draw/draw_test.go
@@ -1,6 +1,7 @@
 package draw
 
 import (
+	"errors"
 	"image"
 	_ "image/png" // Register PNGs for tests
 	"os"
@@ -152,6 +153,30 @@ func TestDrawImageOverlapTitle(t *testing.T) {
 	}
 	if actual, expected := s.pixels[1][2].mainc, '█'; actual != expected {
 		t.Errorf(`rune @ 2, 1 = %q, want %q`, actual, expected)
+	}
+}
+
+// TestDrawError checks that an error message can be drawn to the screen.
+func TestDrawError(t *testing.T) {
+	s := NewMockScreen(12, 11)
+	// TODO line 5 "cannot draw:"
+	// TODO line 6 error message
+	Error(s, errors.New("test"))
+
+	statusLine := make([]rune, 0, 12)
+	for _, p := range s.pixels[5] {
+		statusLine = append(statusLine, p.mainc)
+	}
+	if actual, expected := string(statusLine), "cannot draw:"; actual != expected {
+		t.Errorf(`Status line = %q, want %q`, actual, expected)
+	}
+
+	errorLine := make([]rune, 0, 12)
+	for _, p := range s.pixels[6] {
+		errorLine = append(errorLine, p.mainc)
+	}
+	if actual, expected := string(errorLine), "    test    "; actual != expected {
+		t.Errorf(`Error line = %q, want %q`, actual, expected)
 	}
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -29,6 +29,7 @@ func LoadImage(filename string) (m image.Image, title string, err error) {
 
 	m, format, err := decode(reader)
 	if err != nil {
+		title = filepath.Base(filename)
 		err = fmt.Errorf("Couldn't decode %q: %w", filename, err)
 		return
 	}


### PR DESCRIPTION
In order to allow the user to continue browsing after an error, and to allow cleanup functions to
run, this PR renders errors instead of fatally logging them where possible and applicable.

Resolves #49
