### PR TITLE
Wrap titles that are too long for one line

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/disintegration/imaging v1.6.2
 	github.com/gdamore/tcell/v2 v2.4.0
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/spenserblack/go-wordwrap v0.1.2
 	github.com/spf13/cobra v1.2.1
 	golang.org/x/image v0.0.0-20210504121937-7319ad40d33e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,9 @@ github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
-github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -216,6 +217,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/spenserblack/go-wordwrap v0.1.2 h1:/BdwsynOGO1PbR3xwqMR6Zoq8SXbBSduSWxUbvZMNpU=
+github.com/spenserblack/go-wordwrap v0.1.2/go.mod h1:K9uj2SzzQYG9ZUodmITlApXosf3GjW1xNHPrxVNqG58=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=

--- a/internal/draw/draw.go
+++ b/internal/draw/draw.go
@@ -4,12 +4,13 @@ import (
 	"image"
 
 	"github.com/gdamore/tcell/v2"
+	"github.com/spenserblack/go-wordwrap"
 
 	"github.com/spenserblack/termage/internal/conversion"
 )
 
 // TitleBarPixels is the height of the title bar in "pixels"
-const TitleBarPixels int = 1
+var TitleBarPixels int = 1
 
 func Redraw(s tcell.Screen, title string, rgbRunes conversion.RGBRunes, center image.Point) {
 	s.Clear()
@@ -20,12 +21,16 @@ func Redraw(s tcell.Screen, title string, rgbRunes conversion.RGBRunes, center i
 
 // Title draws an image title to a screen.
 func Title(s tcell.Screen, title string) {
-	runes := []rune(title)
 	width, _ := s.Size()
 	center := width / 2
-	runesStart := center - (len(runes) / 2)
-	for i, r := range runes {
-		s.SetContent(runesStart+i, 0, r, nil, tcell.StyleDefault)
+	lines := wordwrap.WordWrap(title, width)
+	TitleBarPixels = len(lines)
+	for row, line := range lines {
+		runes := []rune(line)
+		runesStart := center - (len(runes) / 2)
+		for i, r := range runes {
+			s.SetContent(runesStart+i, row, r, nil, tcell.StyleDefault)
+		}
 	}
 }
 

--- a/internal/draw/draw_test.go
+++ b/internal/draw/draw_test.go
@@ -236,6 +236,9 @@ func (s *MockScreen) GetContent(x, y int) (
 }
 
 func (s *MockScreen) SetContent(x int, y int, mainc rune, combc []rune, style tcell.Style) {
+	if x < 0 || x >= s.width || y < 0 || y >= s.height {
+		return
+	}
 	s.pixels[y][x].mainc = mainc
 	s.pixels[y][x].combc = combc
 	s.pixels[y][x].style = style

--- a/internal/draw/draw_test.go
+++ b/internal/draw/draw_test.go
@@ -89,6 +89,31 @@ func TestDrawTitle(t *testing.T) {
 	}
 }
 
+// TestDrawMultilineTitle checks that a title cannot fit in one line will get
+// wrapped to the next line.
+func TestDrawMultilineTitle(t *testing.T) {
+	const width int = 7
+	s := NewMockScreen(width, 4)
+	Title(s, "11111 222")
+	var (
+		row1 = make([]rune, width, width)
+		row2 = make([]rune, width, width)
+	)
+	for i, p := range s.pixels[0] {
+		row1[i] = p.mainc
+	}
+	for i, p := range s.pixels[1] {
+		row2[i] = p.mainc
+	}
+
+	if actual, expected := string(row1), " 11111 "; actual != expected {
+		t.Errorf(`Row 1 = %q, want %q`, actual, expected)
+	}
+	if actual, expected := string(row2), "  222  "; actual != expected {
+		t.Errorf(`Row 2 = %q, want %q`, actual, expected)
+	}
+}
+
 // TestDrawImage checks that a standard image fitting the screen can be drawn.
 func TestDrawImage(t *testing.T) {
 	f, err := os.Open(getResource("black-and-transparent-2x2.png"))


### PR DESCRIPTION
When a title is too long to be fully displayed on the first line, this will wrap it to subsequent lines.

Perhaps a maximum number of title lines should be set :thinking:

Resolves #64