### PR TITLE
Update Windows install

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,10 +1,14 @@
-$tempdir = [System.IO.Path]::GetTempPath()
-$repo = [System.IO.Path]::GetRandomFileName()
-$temprepo = Join-Path $tempdir $repo
-git clone https://github.com/spenserblack/termage.git $temprepo
-Push-Location $temprepo
-$version = git describe --tags
-go install -ldflags "-X main.version=${version}" .
-Pop-Location
-echo Removing $temprepo
-Remove-Item -Recurse -Force $temprepo
+if (Test-Path -Path "$Env:ProgramFiles\termage") {
+    Write-Host "Overwriting previous install of termage..."
+} else {
+    Write-Host "Installing termage..."
+    Write-Host "Creating directory in Program Files..."
+    New-Item -Path "$Env:ProgramFiles" -Name "termage" -ItemType "directory"
+    Write-Host "Adding directory to path..."
+    $path = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $newpath = $path + ";$Env:ProgramFiles\termage"
+    [Environment]::SetEnvironmentVariable('Path', $newpath, 'User')
+    Write-Host "Updated Path!"
+    Write-Host "You may need to restart your PowerShell instance for this to take effect."
+}
+Invoke-WebRequest -OutFile "$Env:ProgramFiles\termage\termage.exe" "https://github.com/spenserblack/termage/releases/latest/download/termage-windows.exe"


### PR DESCRIPTION
Download binary from release artifact instead of
cloning repo and building with `go`. This allows
install via PowerShell script without having `go`
installed.