### PR TITLE
Wrap error status

### DIFF
--- a/internal/draw/draw.go
+++ b/internal/draw/draw.go
@@ -74,17 +74,26 @@ func Error(s tcell.Screen, err error) {
 	errStr := err.Error()
 	width, height := s.Size()
 
+	statusLines := wordwrap.WordWrap(status, width)
+	errorLines := wordwrap.WordWrap(errStr, width)
+
 	xOrigin := width / 2
 	yOrigin := (height - TitleBarPixels) / 2
 
-	statusStart := xOrigin - (len(status) / 2)
-	for i, r := range []rune(status) {
-		s.SetContent(statusStart+i, yOrigin+TitleBarPixels-1, r, nil, tcell.StyleDefault)
+	statusY := TitleBarPixels + yOrigin - 1
+	for i, line := range statusLines {
+		statusStart := xOrigin - (len(line) / 2)
+		for j, char := range []rune(line) {
+			s.SetContent(statusStart+j, statusY+i, char, nil, tcell.StyleDefault)
+		}
 	}
 
-	errStart := xOrigin - (len(errStr) / 2)
-	for i, r := range []rune(errStr) {
-		s.SetContent(errStart+i, yOrigin+TitleBarPixels, r, nil, tcell.StyleDefault)
+	errorY := statusY + len(statusLines)
+	for i, line := range errorLines {
+		errStart := xOrigin - (len(line) / 2)
+		for j, char := range []rune(line) {
+			s.SetContent(errStart+j, errorY+i, char, nil, tcell.StyleDefault)
+		}
 	}
 }
 

--- a/internal/draw/draw_test.go
+++ b/internal/draw/draw_test.go
@@ -245,7 +245,7 @@ func TestWrapError(t *testing.T) {
 	}
 	wantStatusLines := [2]string{
 		"  cannot  ",
-		"  draw:   ",
+		"   draw:  ",
 	}
 	for i, want := range wantStatusLines {
 		if actual := string(statusLines[i][:]); actual != want {

--- a/internal/draw/draw_test.go
+++ b/internal/draw/draw_test.go
@@ -231,25 +231,38 @@ func TestDrawError(t *testing.T) {
 	}
 }
 
-// TestDrawBigError checks that an error message will be wrapped if it is
+// TestWrapError checks that an error message will be wrapped if it is
 // too large for the screen.
-func TestDrawBigError(t *testing.T) {
+func TestWrapError(t *testing.T) {
 	s := NewMockScreen(10, 13)
 	Error(s, errors.New("this error is big"))
 
-	var errorLines [2][10]rune
+	var statusLines [2][10]rune
+	for y, row := range s.pixels[7:9] {
+		for x, pixel := range row {
+			statusLines[y][x] = pixel.mainc
+		}
+	}
+	wantStatusLines := [2]string{
+		"  cannot  ",
+		"  draw:   ",
+	}
+	for i, want := range wantStatusLines {
+		if actual := string(statusLines[i][:]); actual != want {
+			t.Errorf(`Status line %d = %q, want %q`, i, actual, want)
+		}
+	}
 
-	for y, row := range s.pixels[8:10] {
+	var errorLines [2][10]rune
+	for y, row := range s.pixels[9:11] {
 		for x, pixel := range row {
 			errorLines[y][x] = pixel.mainc
 		}
 	}
-
 	wantErrorLines := [2]string{
 		"this error",
 		"  is big  ",
 	}
-
 	for i, want := range wantErrorLines {
 		if actual := string(errorLines[i][:]); actual != want {
 			t.Errorf(`Error line %d = %q, want %q`, i, actual, want)

--- a/internal/draw/draw_test.go
+++ b/internal/draw/draw_test.go
@@ -231,6 +231,32 @@ func TestDrawError(t *testing.T) {
 	}
 }
 
+// TestDrawBigError checks that an error message will be wrapped if it is
+// too large for the screen.
+func TestDrawBigError(t *testing.T) {
+	s := NewMockScreen(10, 13)
+	Error(s, errors.New("this error is big"))
+
+	var errorLines [2][10]rune
+
+	for y, row := range s.pixels[8:10] {
+		for x, pixel := range row {
+			errorLines[y][x] = pixel.mainc
+		}
+	}
+
+	wantErrorLines := [2]string{
+		"this error",
+		"  is big  ",
+	}
+
+	for i, want := range wantErrorLines {
+		if actual := string(errorLines[i][:]); actual != want {
+			t.Errorf(`Error line %d = %q, want %q`, i, actual, want)
+		}
+	}
+}
+
 type MockScreen struct {
 	width, height int
 	pixels        [][]MockPixel


### PR DESCRIPTION
This wraps the error status to fit in the terminal's horizontal boundaries.

Resolves #65