### PR TITLE
Fix image not cleared on animation

### DIFF
--- a/internal/draw/draw.go
+++ b/internal/draw/draw.go
@@ -121,5 +121,5 @@ func ClearImage(s tcell.Screen) {
 // clearImage is the inner function that takes the screen size and height
 // parameters.
 func clearImage(s tcell.Screen, width, height int) {
-	clearRow(s, TitleBarPixels+1, height, width)
+	clearRow(s, TitleBarPixels, height, width)
 }

--- a/internal/draw/draw.go
+++ b/internal/draw/draw.go
@@ -21,8 +21,8 @@ func Redraw(s tcell.Screen, title string, rgbRunes conversion.RGBRunes, center i
 
 // Title draws an image title to a screen.
 func Title(s tcell.Screen, title string) {
-	clearRow(s, 0, TitleBarPixels)
 	width, _ := s.Size()
+	clearRow(s, 0, TitleBarPixels, width)
 	center := width / 2
 	lines := wordwrap.WordWrap(title, width)
 	for row, line := range lines {
@@ -42,7 +42,7 @@ func Title(s tcell.Screen, title string) {
 func Image(s tcell.Screen, rgbRunes conversion.RGBRunes, center image.Point) {
 	width, height := rgbRunes.Width(), rgbRunes.Height()
 	screenWidth, screenHeight := s.Size()
-	clearRow(s, TitleBarPixels+1, screenHeight)
+	clearImage(s, screenWidth, screenHeight)
 	xOrigin := screenWidth / 2
 	yOrigin := (screenHeight - TitleBarPixels) / 2
 	for x := 0; x < width; x++ {
@@ -98,11 +98,28 @@ func Error(s tcell.Screen, err error) {
 }
 
 // ClearRow clears a single row of a Screen.
-func clearRow(s tcell.Screen, start, end int) {
+func ClearRow(s tcell.Screen, start, end int) {
 	width, _ := s.Size()
+	clearRow(s, start, end, width)
+}
+
+// clearRow is the inner function that takes the screen width as a parameter.
+func clearRow(s tcell.Screen, start, end int, width int) {
 	for row := start; row <= end; row++ {
 		for cell := 0; cell < width; cell++ {
 			s.SetContent(cell, row, ' ', nil, tcell.StyleDefault)
 		}
 	}
+}
+
+// ClearImage clears all rows where the image would be drawn.
+func ClearImage(s tcell.Screen) {
+	width, height := s.Size()
+	clearImage(s, width, height)
+}
+
+// clearImage is the inner function that takes the screen size and height
+// parameters.
+func clearImage(s tcell.Screen, width, height int) {
+	clearRow(s, TitleBarPixels+1, height, width)
 }

--- a/internal/draw/draw_test.go
+++ b/internal/draw/draw_test.go
@@ -270,6 +270,85 @@ func TestWrapError(t *testing.T) {
 	}
 }
 
+// TestClearRow tests that specified rows would be cleared.
+func TestClearRow(t *testing.T) {
+	const (
+		width  int = 10
+		height int = 10
+	)
+	s := NewMockScreen(width, height)
+
+	// NOTE Putting some fake content into the screen
+	for x := 0; x < width; x++ {
+		for y := 0; y < height; y++ {
+			var pixel rune
+			if (x+y)%2 == 0 {
+				pixel = 'x'
+			} else {
+				pixel = 'o'
+			}
+			s.SetContent(x, y, pixel, nil, tcell.StyleDefault)
+		}
+	}
+
+	ClearRow(s, 4, 6)
+
+	unclearedRows := [][2]int{{0, 3}, {7, 9}}
+
+	for _, rowRange := range unclearedRows {
+		start := rowRange[0]
+		end := rowRange[1]
+
+		for y := start; y <= end; y++ {
+			for x, pixel := range s.pixels[y] {
+				if pixel.mainc == ' ' {
+					t.Errorf(`Want pixel @ %d, %d to *not* be clear`, x, y)
+				}
+			}
+		}
+	}
+
+	for y := 4; y <= 6; y++ {
+		for x, pixel := range s.pixels[y] {
+			if pixel.mainc != ' ' {
+				t.Errorf(`Pixel @ %d, %d = %q, want ' '`, x, y, pixel.mainc)
+			}
+		}
+	}
+}
+
+// TestClearImage tests that the area dedicated to the image would be cleared.
+func TestClearImage(t *testing.T) {
+	const (
+		width  int = 10
+		height int = 10
+	)
+	s := NewMockScreen(width, height)
+
+	// NOTE Putting some fake content into the screen
+	for x := 0; x < width; x++ {
+		for y := 0; y < height; y++ {
+			var pixel rune
+			if (x+y)%2 == 0 {
+				pixel = 'x'
+			} else {
+				pixel = 'o'
+			}
+			s.SetContent(x, y, pixel, nil, tcell.StyleDefault)
+		}
+	}
+
+	ClearImage(s)
+
+	for y, row := range s.pixels[TitleBarPixels+1:] {
+		for x, pixel := range row {
+			if pixel.mainc != ' ' {
+				t.Errorf(`Pixel @ %d, %d = %q, want ' '`, x, y, pixel.mainc)
+			}
+		}
+	}
+}
+
 type MockScreen struct {
 	width, height int
 	pixels        [][]MockPixel

--- a/internal/draw/draw_test.go
+++ b/internal/draw/draw_test.go
@@ -340,7 +340,7 @@ func TestClearImage(t *testing.T) {
 
 	ClearImage(s)
 
-	for y, row := range s.pixels[TitleBarPixels+1:] {
+	for y, row := range s.pixels[TitleBarPixels:] {
 		for x, pixel := range row {
 			if pixel.mainc != ' ' {
 				t.Errorf(`Pixel @ %d, %d = %q, want ' '`, x, y, pixel.mainc)


### PR DESCRIPTION
Clears the previous image when switching to an animated image. Previously, an image would only be
cleared if the following image was *not* animated.

Fixes #83
